### PR TITLE
Fix handling of boundary DateTime values in other timezones.

### DIFF
--- a/src/TypeShape.Examples/CborSerializer/Converters/PrimitiveConverters.cs
+++ b/src/TypeShape.Examples/CborSerializer/Converters/PrimitiveConverters.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Formats.Cbor;
+using System.Globalization;
 using System.Numerics;
 using System.Text;
 
@@ -315,11 +316,20 @@ internal sealed class GuidConverter : CborConverter<Guid>
 
 internal sealed class DateTimeConverter : CborConverter<DateTime>
 {
+    private const string Rfc3339FormatString = "yyyy-MM-ddTHH:mm:ss.FFFFFFFK";
+
     public override DateTime Read(CborReader reader)
-        => reader.ReadDateTimeOffset().DateTime;
+    {
+        reader.EnsureTag(CborTag.DateTimeString);
+        string dateString = reader.ReadTextString();
+        return DateTime.ParseExact(dateString, Rfc3339FormatString, CultureInfo.InvariantCulture);
+    }
 
     public override void Write(CborWriter writer, DateTime value)
-        => writer.WriteDateTimeOffset(new DateTimeOffset(value));
+    {
+        writer.WriteTag(CborTag.DateTimeString);
+        writer.WriteTextString(value.ToString(Rfc3339FormatString, CultureInfo.InvariantCulture));
+    }
 }
 
 internal sealed class DateTimeOffsetConverter : CborConverter<DateTimeOffset>

--- a/src/TypeShape.Examples/XmlSerializer/Converters/PrimitiveConverters.cs
+++ b/src/TypeShape.Examples/XmlSerializer/Converters/PrimitiveConverters.cs
@@ -289,7 +289,7 @@ internal sealed class DateTimeConverter : XmlConverter<DateTime>
     public override void Write(XmlWriter writer, string localName, DateTime value)
     {
         writer.WriteStartElement(localName);
-        writer.WriteValue(new DateTimeOffset(value));
+        writer.WriteValue(value);
         writer.WriteEndElement();
     }
 }


### PR DESCRIPTION
A couple of converters were delegating `DateTime` serialization to `DateTimeOffset`, which was causing a number of tests to fail in machines with western hemisphere timezones.

Fix https://github.com/eiriktsarpalis/typeshape-csharp/issues/16

cc @AArnott 