### PR TITLE
Lower Roslyn version back to 4.8

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Source Generator dependencies -->
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <!-- Build Infra & Packaging -->
     <PackageVersion Include="PolySharp" Version="1.14.1" />


### PR DESCRIPTION
Lowered the Roslyn dependency to 4.8 since there are many places in the source generator that assume C# 12 features.

Fix #18.