### PR TITLE
Lower TypeShape.Roslyn Roslyn dependency to 3.11

### DIFF
--- a/src/TypeShape.Roslyn/Model/PropertyDataModel.cs
+++ b/src/TypeShape.Roslyn/Model/PropertyDataModel.cs
@@ -14,7 +14,7 @@ public readonly struct PropertyDataModel
     public PropertyDataModel(IPropertySymbol property)
     {
         PropertySymbol = property;
-        IsRequired = property.IsRequired;
+        IsRequired = property.IsRequired();
     }
 
     /// <summary>
@@ -23,7 +23,7 @@ public readonly struct PropertyDataModel
     public PropertyDataModel(IFieldSymbol field)
     {
         PropertySymbol = field;
-        IsRequired = field.IsRequired;
+        IsRequired = field.IsRequired();
     }
 
     /// <summary>

--- a/src/TypeShape.Roslyn/TypeShape.Roslyn.csproj
+++ b/src/TypeShape.Roslyn/TypeShape.Roslyn.csproj
@@ -13,6 +13,6 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="3.11.0" />
     </ItemGroup>
 </Project>

--- a/src/TypeShape.SourceGenerator/TypeShape.SourceGenerator.csproj
+++ b/src/TypeShape.SourceGenerator/TypeShape.SourceGenerator.csproj
@@ -3,6 +3,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <DefineConstants Condition="'$(LaunchDebugger)' == 'true'">$(DefineConstants);LAUNCH_DEBUGGER</DefineConstants>
+        <DefineConstants>$(DefineConstants);ROSLYN4_4_OR_GREATER</DefineConstants>
         <PackFolder>analyzers/dotnet/cs</PackFolder>
         <PackSymbols>false</PackSymbols>
     </PropertyGroup>


### PR DESCRIPTION
Following up on #20 this lowers the TypeShape.Roslyn dependency to 3.11. It turns out that the only missing APIs required by this layer is required properties which can be looked up using reflection.

Contributes to https://github.com/eiriktsarpalis/typeshape-csharp/issues/18

cc @AArnott 