### PR TITLE
Stop writing emitted files to disk

### DIFF
--- a/tests/TypeShape.Tests/TypeShape.Tests.csproj
+++ b/tests/TypeShape.Tests/TypeShape.Tests.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <WarningsAsErrors>Nullable</WarningsAsErrors>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <DefineConstants>IS_TEST_PROJECT</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
On the second computer I've cloned this repo down to, the build fails because one of the files the compiler tries to write has a file length that's too long:
'D:\source\typeshape-csharp\tests\TypeShape.Tests\obj\Debug\net8.0\generated\TypeShape.SourceGenerator\TypeShape.SourceGenerator.TypeShapeIncrementalGenerator\TypeShape.Tests.SourceGenProvider.ValueTuple_Int32_Int32_Int32_Int32_Int32_Int32_Int32_Int32_Int32.g.cs' is 261 characters long

It's odd that this path is shorter than my first computer, which has no problem with builds (although many tools and features of Windows are still unable to process this file or even delete it).

I suggest in the interest in making this repo more consumable by more people and machines, that we turn off generated file emission on disk. Folks can always look at the generated code through Solution Explorer:
![image](https://github.com/user-attachments/assets/039d5c10-5cec-4951-b6ff-db1fd30a81fc)

Note however that this code will be generated by the _first_ version of the generator that VS could load for that process. Any changes made to the source generator after that won't be reflected in the generated code accessible in Solution Explorer until those changes are built and VS is restarted. So if your "inner loop" involves making changes and reviewing them, turning this property back on (but not checking it in, preferably) would perhaps be the best path.